### PR TITLE
Add support for GET requests in pghistory middleware

### DIFF
--- a/pghistory/middleware.py
+++ b/pghistory/middleware.py
@@ -28,7 +28,7 @@ def HistoryMiddleware(get_response):
     """
 
     def middleware(request):
-        if request.method in ('POST', 'PUT', 'PATCH', 'DELETE'):
+        if request.method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             with pghistory.context(
                 user=request.user.id if hasattr(request, 'user') else None,
                 url=request.path,


### PR DESCRIPTION
Adds pghistory context to GET requests. This is useful especially when tracking updates to the User model, which various Django auth middlewares will often mutate to set the last login date.

Type: feature